### PR TITLE
Add UseCompactPlaylistView setting with UI, migration and view switching

### DIFF
--- a/Listen2MeRefined.Infrastructure/Migrations/20260301000000_AddPlaylistViewModeSetting.cs
+++ b/Listen2MeRefined.Infrastructure/Migrations/20260301000000_AddPlaylistViewModeSetting.cs
@@ -1,0 +1,33 @@
+#nullable disable
+
+using Listen2MeRefined.Infrastructure.Data.EntityFramework;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Listen2MeRefined.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(DataContext))]
+    [Migration("20260301000000_AddPlaylistViewModeSetting")]
+    public partial class AddPlaylistViewModeSetting : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "UseCompactPlaylistView",
+                table: "Settings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UseCompactPlaylistView",
+                table: "Settings");
+        }
+    }
+}

--- a/Listen2MeRefined.Infrastructure/Migrations/DataContextModelSnapshot.cs
+++ b/Listen2MeRefined.Infrastructure/Migrations/DataContextModelSnapshot.cs
@@ -88,6 +88,9 @@ namespace Listen2MeRefined.Infrastructure.Migrations
                     b.Property<float>("StartupVolume")
                         .HasColumnType("REAL");
 
+                    b.Property<bool>("UseCompactPlaylistView")
+                        .HasColumnType("INTEGER");
+
                     b.HasKey("Id");
 
                     b.ToTable("Settings");

--- a/Listen2MeRefined.Infrastructure/Notifications/PlaylistViewModeChangedNotification.cs
+++ b/Listen2MeRefined.Infrastructure/Notifications/PlaylistViewModeChangedNotification.cs
@@ -1,0 +1,11 @@
+namespace Listen2MeRefined.Infrastructure.Notifications;
+
+public sealed class PlaylistViewModeChangedNotification : INotification
+{
+    public PlaylistViewModeChangedNotification(bool useCompactPlaylistView)
+    {
+        UseCompactPlaylistView = useCompactPlaylistView;
+    }
+
+    public bool UseCompactPlaylistView { get; }
+}

--- a/Listen2MeRefined.Infrastructure/Settings/AppSettings.cs
+++ b/Listen2MeRefined.Infrastructure/Settings/AppSettings.cs
@@ -21,6 +21,7 @@ public sealed class AppSettings : Settings
     public float StartupVolume { get; set; } = 0.7f;
     public bool StartMuted { get; set; }
     public bool AutoCheckUpdatesOnStartup { get; set; } = true;
+    public bool UseCompactPlaylistView { get; set; }
     public bool AutoScanOnFolderAdd { get; set; } = true;
     public bool ShowTaskPercentage { get; set; } = true;
     public short TaskPercentageReportInterval { get; set; } = 1;

--- a/Listen2MeRefined.Infrastructure/Settings/AppSettingsReader.cs
+++ b/Listen2MeRefined.Infrastructure/Settings/AppSettingsReader.cs
@@ -28,6 +28,7 @@ public sealed class AppSettingsReader : IAppSettingsReader
     public float GetStartupVolume() => _settingsManager.Settings.StartupVolume;
     public bool GetStartMuted() => _settingsManager.Settings.StartMuted;
     public bool GetAutoCheckUpdatesOnStartup() => _settingsManager.Settings.AutoCheckUpdatesOnStartup;
+    public bool GetUseCompactPlaylistView() => _settingsManager.Settings.UseCompactPlaylistView;
     public bool GetAutoScanOnFolderAdd() => _settingsManager.Settings.AutoScanOnFolderAdd;
     public bool GetShowTaskPercentage() => _settingsManager.Settings.ShowTaskPercentage;
     public short GetTaskPercentageReportInterval() => _settingsManager.Settings.TaskPercentageReportInterval;

--- a/Listen2MeRefined.Infrastructure/Settings/AppSettingsWriter.cs
+++ b/Listen2MeRefined.Infrastructure/Settings/AppSettingsWriter.cs
@@ -67,6 +67,11 @@ public sealed class AppSettingsWriter : IAppSettingsWriter
         _settingsManager.SaveSettings(s => s.AutoCheckUpdatesOnStartup = value);
     }
 
+    public void SetUseCompactPlaylistView(bool value)
+    {
+        _settingsManager.SaveSettings(s => s.UseCompactPlaylistView = value);
+    }
+
     public void SetAutoScanOnFolderAdd(bool value)
     {
         _settingsManager.SaveSettings(s => s.AutoScanOnFolderAdd = value);

--- a/Listen2MeRefined.Infrastructure/Settings/IAppSettingsReader.cs
+++ b/Listen2MeRefined.Infrastructure/Settings/IAppSettingsReader.cs
@@ -34,6 +34,8 @@ public interface IAppSettingsReader
     bool GetStartMuted();
     /// <summary>Gets whether automatic update checks on startup are enabled.</summary>
     bool GetAutoCheckUpdatesOnStartup();
+    /// <summary>Gets whether playlist uses compact visual rows.</summary>
+    bool GetUseCompactPlaylistView();
     /// <summary>Gets whether a folder should be auto-scanned when added.</summary>
     bool GetAutoScanOnFolderAdd();
     /// <summary>Gets whether background task percentage should be shown in the title bar.</summary>

--- a/Listen2MeRefined.Infrastructure/Settings/IAppSettingsWriter.cs
+++ b/Listen2MeRefined.Infrastructure/Settings/IAppSettingsWriter.cs
@@ -30,6 +30,8 @@ public interface IAppSettingsWriter
     void SetStartMuted(bool value);
     /// <summary>Sets whether automatic update checks on startup are enabled.</summary>
     void SetAutoCheckUpdatesOnStartup(bool value);
+    /// <summary>Sets whether playlist uses compact visual rows.</summary>
+    void SetUseCompactPlaylistView(bool value);
     /// <summary>Sets whether a folder should be auto-scanned when added.</summary>
     void SetAutoScanOnFolderAdd(bool value);
     /// <summary>Sets whether background task percentage should be shown in the title bar.</summary>

--- a/Listen2MeRefined.Infrastructure/ViewModels/MainWindow/PlaylistPaneViewModel.cs
+++ b/Listen2MeRefined.Infrastructure/ViewModels/MainWindow/PlaylistPaneViewModel.cs
@@ -1,12 +1,17 @@
 using System.Collections;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using Listen2MeRefined.Infrastructure.Notifications;
 
 namespace Listen2MeRefined.Infrastructure.ViewModels.MainWindow;
 
-public partial class PlaylistPaneViewModel : ViewModelBase
+public partial class PlaylistPaneViewModel :
+    ViewModelBase,
+    INotificationHandler<PlaylistViewModeChangedNotification>
 {
     private readonly ListsViewModel _lists;
+
+    [ObservableProperty] private bool _isCompactPlaylistView;
 
     public ObservableCollection<AudioModel> PlayList => _lists.PlayList;
 
@@ -26,9 +31,10 @@ public partial class PlaylistPaneViewModel : ViewModelBase
     public IAsyncRelayCommand JumpToSelectedSongCommand => _lists.JumpToSelectedSongCommand;
     public IRelayCommand SwitchToSongMenuTabCommand => _lists.SwitchToSongMenuTabCommand;
 
-    public PlaylistPaneViewModel(ListsViewModel lists)
+    public PlaylistPaneViewModel(ListsViewModel lists, IAppSettingsReader settingsReader)
     {
         _lists = lists;
+        IsCompactPlaylistView = settingsReader.GetUseCompactPlaylistView();
         _lists.PropertyChanged += ListsOnPropertyChanged;
     }
 
@@ -37,6 +43,12 @@ public partial class PlaylistPaneViewModel : ViewModelBase
 
     [RelayCommand]
     private void PlaylistSelectionRemoved(IList items) => _lists.RemoveSelectedPlaylistItems(items.Cast<AudioModel>());
+
+    public Task Handle(PlaylistViewModeChangedNotification notification, CancellationToken cancellationToken)
+    {
+        IsCompactPlaylistView = notification.UseCompactPlaylistView;
+        return Task.CompletedTask;
+    }
 
     private void ListsOnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {

--- a/Listen2MeRefined.Infrastructure/ViewModels/SettingsWindowViewModel.cs
+++ b/Listen2MeRefined.Infrastructure/ViewModels/SettingsWindowViewModel.cs
@@ -72,6 +72,7 @@ public sealed partial class SettingsWindowViewModel :
     [ObservableProperty] private int _startupVolumePercent = 70;
     [ObservableProperty] private bool _startMuted;
     [ObservableProperty] private bool _autoCheckUpdatesOnStartup = true;
+    [ObservableProperty] private string _selectedPlaylistViewMode = "Detailed";
     [ObservableProperty] private bool _autoScanOnFolderAdd = true;
     [ObservableProperty] private bool _showTaskPercentage = true;
     [ObservableProperty] private int _taskPercentageReportInterval = 1;
@@ -84,6 +85,9 @@ public sealed partial class SettingsWindowViewModel :
 
     public ObservableCollection<TaskStatusCountBasis> ScanMilestoneBases { get; } =
         new(Enum.GetValues<TaskStatusCountBasis>());
+
+    public ObservableCollection<string> PlaylistViewModes { get; } =
+        new(new[] { "Detailed", "Compact" });
 
     public bool ScanOnStartup
     {
@@ -172,6 +176,7 @@ public sealed partial class SettingsWindowViewModel :
         StartupVolumePercent = _playbackDefaultsService.ToVolumePercent(_settingsReader.GetStartupVolume());
         StartMuted = _settingsReader.GetStartMuted();
         AutoCheckUpdatesOnStartup = _settingsReader.GetAutoCheckUpdatesOnStartup();
+        SelectedPlaylistViewMode = _settingsReader.GetUseCompactPlaylistView() ? "Compact" : "Detailed";
         AutoScanOnFolderAdd = _settingsReader.GetAutoScanOnFolderAdd();
         ShowTaskPercentage = _settingsReader.GetShowTaskPercentage();
         TaskPercentageReportInterval = Math.Clamp(
@@ -371,6 +376,19 @@ public sealed partial class SettingsWindowViewModel :
             UpdateAvailableText = "Automatic update checks are disabled.";
             IsUpdateButtonVisible = false;
         }
+    }
+
+
+    partial void OnSelectedPlaylistViewModeChanged(string value)
+    {
+        if (_isLoadingSettings || string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        var useCompactPlaylistView = string.Equals(value, "Compact", StringComparison.Ordinal);
+        _settingsWriter.SetUseCompactPlaylistView(useCompactPlaylistView);
+        _ = _mediator.Publish(new PlaylistViewModeChangedNotification(useCompactPlaylistView));
     }
 
     partial void OnAutoScanOnFolderAddChanged(bool value)

--- a/Listen2MeRefined.WPF/Views/MainWindow/PlaylistPaneView.xaml
+++ b/Listen2MeRefined.WPF/Views/MainWindow/PlaylistPaneView.xaml
@@ -54,27 +54,47 @@
                 <ListView.ItemTemplate>
                     <DataTemplate>
                         <Grid MinWidth="320" ClipToBounds="True">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto" />
-                                <RowDefinition Height="8" />
-                                <RowDefinition Height="Auto" />
-                            </Grid.RowDefinitions>
+                            <Grid x:Name="DetailedViewRoot">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="8" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
 
-                            <resources:StoryboardTextBlock Text="{Binding Display, FallbackValue=Track}"
+                                <resources:StoryboardTextBlock Text="{Binding Display, FallbackValue=Track}"
+                                                               Foreground="#D7D7D7"
+                                                               FontSize="16"
+                                                               FontWeight="Bold"
+                                                               TextTrimming="None"
+                                                               HorizontalAlignment="Left"
+                                                               ClipToBounds="True"
+                                                               utils:FlowingTextBehavior.IsEnabled="True" />
+
+                                <components:MetaBadgeRow Grid.Row="2"
+                                                         BpmText="{Binding BPM, StringFormat={}{0} BPM, FallbackValue=BPM}"
+                                                         BitrateText="{Binding Bitrate, StringFormat={}{0} Kbps, FallbackValue=Bitrate}"
+                                                         LengthText="{Binding Length, StringFormat={}{0:hh\:mm\:ss\.f}, FallbackValue=Length}"
+                                                         GenreText="{Binding Genre, FallbackValue=Genre}" />
+                            </Grid>
+
+                            <resources:StoryboardTextBlock x:Name="CompactViewText"
+                                                           Text="{Binding Display, FallbackValue=Track}"
                                                            Foreground="#D7D7D7"
                                                            FontSize="16"
                                                            FontWeight="Bold"
                                                            TextTrimming="None"
                                                            HorizontalAlignment="Left"
                                                            ClipToBounds="True"
+                                                           Visibility="Collapsed"
                                                            utils:FlowingTextBehavior.IsEnabled="True" />
-
-                            <components:MetaBadgeRow Grid.Row="2"
-                                                     BpmText="{Binding BPM, StringFormat={}{0} BPM, FallbackValue=BPM}"
-                                                     BitrateText="{Binding Bitrate, StringFormat={}{0} Kbps, FallbackValue=Bitrate}"
-                                                     LengthText="{Binding Length, StringFormat={}{0:hh\\:mm\\:ss\\.f}, FallbackValue=Length}"
-                                                     GenreText="{Binding Genre, FallbackValue=Genre}" />
                         </Grid>
+                        <DataTemplate.Triggers>
+                            <DataTrigger Binding="{Binding DataContext.IsCompactPlaylistView, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                         Value="True">
+                                <Setter TargetName="DetailedViewRoot" Property="Visibility" Value="Collapsed" />
+                                <Setter TargetName="CompactViewText" Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </DataTemplate.Triggers>
                     </DataTemplate>
                 </ListView.ItemTemplate>
             </ListView>

--- a/Listen2MeRefined.WPF/Views/SettingsWindow.xaml
+++ b/Listen2MeRefined.WPF/Views/SettingsWindow.xaml
@@ -83,6 +83,16 @@
                                             </components:FormFieldRow.FieldContent>
                                         </components:FormFieldRow>
 
+                                        <components:FormFieldRow Margin="0,0,0,10"
+                                                                 Label="Playlist view:"
+                                                                 LabelWidth="170">
+                                            <components:FormFieldRow.FieldContent>
+                                                <ComboBox Style="{StaticResource CustomComboBox}"
+                                                          SelectedItem="{Binding SelectedPlaylistViewMode}"
+                                                          ItemsSource="{Binding PlaylistViewModes}" />
+                                            </components:FormFieldRow.FieldContent>
+                                        </components:FormFieldRow>
+
                                         <CheckBox IsChecked="{Binding AutoCheckUpdatesOnStartup}"
                                                   Content="Automatically check for updates on startup"
                                                   Margin="0,0,0,10" />


### PR DESCRIPTION
### Motivation
- Provide a user-configurable option to switch the playlist display between a detailed and a compact row view and persist that preference. 
- Ensure the UI responds immediately when the playlist view mode is changed by broadcasting a notification so open playlist panes can update without restart.

### Description
- Add a new `bool` setting `UseCompactPlaylistView` to `AppSettings`, exposed via `IAppSettingsReader`/`IAppSettingsWriter` and wired into `AppSettingsReader`, `AppSettingsWriter`, `IAppSettingsReader`, and `IAppSettingsWriter` methods. 
- Add an EF Core migration `20260301000000_AddPlaylistViewModeSetting` and update the `DataContextModelSnapshot` to add the `UseCompactPlaylistView` column to the `Settings` table. 
- Add `PlaylistViewModeChangedNotification` and publish it from `SettingsWindowViewModel` when `SelectedPlaylistViewMode` changes, and implement `INotificationHandler<PlaylistViewModeChangedNotification>` in `PlaylistPaneViewModel` so panes update `IsCompactPlaylistView` at runtime. 
- Update settings UI and playlist view: add a `Playlist view` `ComboBox` and `PlaylistViewModes` in `SettingsWindowViewModel`, and modify `PlaylistPaneView.xaml` to switch between detailed and compact item templates using a `DataTrigger` bound to `IsCompactPlaylistView`.

### Testing
- Built the solution with `dotnet build` and executed unit tests with `dotnet test`, and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49fb83ca0832cad6caf8ead362d7d)