### PR TITLE
Breaking: Fixed impossibly big BPM values.

### DIFF
--- a/Listen2MeRefined.Infrastructure/Scanning/Files/SoundFileAnalyzer.cs
+++ b/Listen2MeRefined.Infrastructure/Scanning/Files/SoundFileAnalyzer.cs
@@ -29,11 +29,29 @@ public sealed class SoundFileAnalyzer : IFileAnalyzer<AudioModel>
             Title = file.Tag.Title,
             Artist = string.Join("; ", file.Tag.Performers!),
             Genre = string.Join("; ", file.Tag.Genres!),
-            BPM = file.Tag.BeatsPerMinute,
+            BPM = SanitizeBpm(file.Tag.BeatsPerMinute),
             Bitrate = (short)file.Properties.AudioBitrate,
             Length = file.Properties.Duration,
             LastWriteUtc = info.LastWriteTimeUtc,
             LengthBytes = info.Length
         };
+    }
+
+    /// <summary>
+    /// Handles BPM values inflated by decimal-format tags (e.g. "150.000000" parsed as 150000000).
+    /// Divides by increasing powers of 10 and rounds to recover the real value; returns 0 if unrecoverable.
+    /// </summary>
+    internal static uint SanitizeBpm(uint bpm)
+    {
+        const uint maxReasonableBpm = 999;
+
+        if (bpm <= maxReasonableBpm)
+            return bpm;
+
+        var divisor = 10u;
+        while (bpm / divisor > maxReasonableBpm)
+            divisor *= 10;
+
+        return (uint)Math.Round((double)bpm / divisor);
     }
 }

--- a/Listen2MeRefined.Tests/Scanning/Files/SoundFileAnalyzerTests.cs
+++ b/Listen2MeRefined.Tests/Scanning/Files/SoundFileAnalyzerTests.cs
@@ -1,0 +1,28 @@
+using Listen2MeRefined.Infrastructure.Scanning.Files;
+
+namespace Listen2MeRefined.Tests.Scanning.Files;
+
+public class SoundFileAnalyzerTests
+{
+    [Theory]
+    [InlineData(0u, 0u)]
+    [InlineData(120u, 120u)]
+    [InlineData(150u, 150u)]
+    [InlineData(999u, 999u)]
+    [InlineData(150_000_000u, 150u)]
+    [InlineData(155_000_000u, 155u)]
+    [InlineData(154_990_000u, 155u)]
+    [InlineData(139_510_000u, 140u)]
+    [InlineData(160_000_00u, 160u)]
+    [InlineData(1500u, 150u)]
+    [InlineData(15_000u, 150u)]
+    [InlineData(1001u, 100u)]
+    [InlineData(3_000_000u, 300u)]
+    [InlineData(174_600_000u, 175u)]
+    public void SanitizeBpm_ValidOrInflated_ReturnsExpected(uint input, uint expected)
+    {
+        var result = SoundFileAnalyzer.SanitizeBpm(input);
+
+        Assert.Equal(expected, result);
+    }
+}


### PR DESCRIPTION
Due to the nature of this bug, every affected song needs to be rescanned.

Source of the bug: I analyzed some of my song with Serato 3.0, which saved the BPM with trailing zeros, like: 150.000000
TagLib's algorithm doesn't take the dot into account, resulting in 150 million BPM.

Since I deemed it as a valid analyzing technique, support is now added for these cases:
 - Every BPM value above 999 is clamped and rounded.